### PR TITLE
Fix spotify auth scope and remove unused code

### DIFF
--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -9,7 +9,7 @@ export const options: NextAuthOptions = {
       authorization: {
         params: {
           scope:
-            "ugc-image-upload playlist-read-private playlist-read-collaborative playlist-modify-public playlist-modify-private user-library-read user-library-modify user-read-email ",
+            "ugc-image-upload playlist-read-private playlist-read-collaborative playlist-modify-public playlist-modify-private user-library-read user-library-modify user-read-email",
         },
       },
     }),

--- a/app/api/createPlaylist/route.ts
+++ b/app/api/createPlaylist/route.ts
@@ -32,15 +32,11 @@ export async function POST(request: Request) {
 
     console.log("Playlist created with ID", id, "and URI", uri);
 
-    const trackUriString = tracks
-      .map((track: TrackRow) => `spotify:track:${track.spotifyId}`)
-      .join(",");
-
     const trackUriArray = tracks.map(
       (track: TrackRow) => `spotify:track:${track.spotifyId}`
     );
 
-    console.log("Adding tracks to playlist", id, "with URIs", trackUriString);
+    console.log("Adding tracks to playlist", id);
     const addTracksResponse = await fetch(
       "https://api.spotify.com/v1/playlists/" + id + "/tracks",
       {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import { ClerkProvider } from "@clerk/nextjs";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });

--- a/components/CreatePlaylist.tsx
+++ b/components/CreatePlaylist.tsx
@@ -1,5 +1,4 @@
-import React, { use } from "react";
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import CreatePlaylistForm from "./CreatePlaylistForm";
 import {
   AlertDialog,
@@ -16,7 +15,6 @@ import { Button } from "@/components/ui/button";
 import { CreatePlaylistModalTable } from "./CreatePlaylistModalTable/data-table";
 import { columns } from "./CreatePlaylistModalTable/columns";
 import { TrackRow } from "./CreatePlaylistModalTable/columns";
-import { create } from "lodash";
 import { TrackListContext } from "@/state/globalState";
 
 interface CreatePlaylistProps {
@@ -37,7 +35,6 @@ const CreatePlaylist = (props: CreatePlaylistProps) => {
   const [open, setOpen] = useState(false);
   const handleOpen = () => {
     setOpen(true);
-    console.log("handleOpen called");
   };
 
   const context = React.useContext(TrackListContext);

--- a/components/CreatePlaylistForm.tsx
+++ b/components/CreatePlaylistForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { TrackRow } from "./CreatePlaylistModalTable/columns";
 import { useForm } from "react-hook-form";
@@ -43,10 +43,8 @@ const CreatePlaylistForm: React.FC<CreatePlaylistFormProps> = ({
   tracks,
   createPlaylist,
 }) => {
-  const [setlistName, setsetlistName] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
-  const [id, setid] = useState<string>("");
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),

--- a/components/CreatePlaylistModalTable/pagination.tsx
+++ b/components/CreatePlaylistModalTable/pagination.tsx
@@ -31,7 +31,6 @@ export function SelectedDataTablePagination<TData>({
             value={`${table.getState().pagination.pageSize}`} //default page size
             onValueChange={(value) => {
               table.setPageSize(Number(value));
-              console.log("page size", value);
             }}
           >
             <SelectTrigger className="h-8 w-[70px]">

--- a/components/DataTable/data-table.tsx
+++ b/components/DataTable/data-table.tsx
@@ -272,7 +272,7 @@ async function createPlaylist(
           accessToken: accessToken,
           name: name,
           description: description,
-          visibility: true,
+          visibility: visibility,
         }),
       }
     );
@@ -289,12 +289,4 @@ async function createPlaylist(
   } catch (error) {
     console.error("Error fetching tracks:", error);
   }
-  console.log(
-    "Creating playlist",
-    name,
-    description,
-    visibility,
-    userID,
-    tracks
-  );
 }

--- a/components/DataTable/pagination.tsx
+++ b/components/DataTable/pagination.tsx
@@ -35,7 +35,6 @@ export function DataTablePagination<TData>({
             value={`${table.getState().pagination.pageSize}`} //default page size
             onValueChange={(value) => {
               table.setPageSize(Number(value));
-              console.log("page size", value);
             }}
           >
             <SelectTrigger className="h-8 w-[70px]">

--- a/components/TrackList.tsx
+++ b/components/TrackList.tsx
@@ -202,7 +202,6 @@ async function getUserID(accessToken: string | undefined) {
     }
 
     const data = await response.json();
-    console.log(data);
     return data;
   } catch (error) {
     console.error("Error fetching userID:", error);


### PR DESCRIPTION
## Summary
- trim trailing space from Spotify scope definition
- remove unused Clerk provider and misc console logs
- clean up unused imports and state in playlist forms
- ensure playlist visibility option is used correctly

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_i_683c79e684348328ad7fc3f2774ba664